### PR TITLE
added param for the custom font path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0 (2016-12-07)
+
+- Added: option for a custom font path
+
+
 ## 1.0.0 (2015-07-25)
 
 - Added: Initial release

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Generate a complete list of fonts and their sources from a directory.
 ## Usage
 
 ``` js
-return require('directory-fonts-complete')('/System Folder/Fonts');
+return require('directory-fonts-complete')('/System Folder/Fonts', ['custom/font/path/on/site']);
 ```
 
 yields

--- a/index.js
+++ b/index.js
@@ -88,8 +88,9 @@ function addFontToFoundryByPath(foundry, resolvedFilePath, relativeFilePath) {
 	}
 }
 
-module.exports = function (relativeDirPath) {
+module.exports = function (relativeDirPath, relativeFontPath) {
 	relativeDirPath = relativeDirPath.replace(/\/$/, '');
+  relativeFontPath = relativeFontPath || relativeDirPath;
 
 	var resolvedDirPath = path.resolve(relativeDirPath);
 
@@ -100,7 +101,7 @@ module.exports = function (relativeDirPath) {
 
 		filePaths.forEach(function (filePath) {
 			var resolvedFilePath = resolvedDirPath + '/' + filePath;
-			var relativeFilePath = relativeDirPath + '/' + filePath;
+			var relativeFilePath = relativeFontPath + '/' + filePath;
 
 			addFontToFoundryByPath(foundry, resolvedFilePath, relativeFilePath);
 		});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "directory-fonts-complete",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Generate a complete list of fonts and their sources from a directory",
 	"keywords": [
 		"directory",
@@ -14,6 +14,10 @@
 		"weights"
 	],
 	"author": "Jonathan Neal <jonathantneal@hotmail.com> (http://jonathantneal.com)",
+  "contributors": [
+	  "Jonathan Neal <jonathantneal@hotmail.com>",
+	  "Ruslan Abdullaev <abdullaev.rt@gmail.com>"
+	],
 	"license": "CC0-1.0",
 	"homepage": "https://github.com/jonathantneal/directory-fonts-complete",
 	"bugs": {


### PR DESCRIPTION
These changes are needed to fix the "hosted" option and allow the user to specify a custom path for font. It has a same behaviour if this parameter omitted.